### PR TITLE
Use valid category in library.properties

### DIFF
--- a/IgniteIotLibs/library.properties
+++ b/IgniteIotLibs/library.properties
@@ -4,6 +4,6 @@ author=Yavuz ERZURUMLU <yavuz.erzurumlu@ardictech.com>
 maintainer=Yavuz ERZURUMLU <yavuz.erzurumlu@ardictech.com>
 sentence=Helper libs for embedded devices.
 paragraph=Write something good here.
-category=*
+category=Other
 architectures=*
 url=https://github.com/ARDICTeknoloji/IgniteIotLibs


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '*' in library IgniteIotLibs is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format